### PR TITLE
docs: clarify order k tag

### DIFF
--- a/protocol/src/order-event.md
+++ b/protocol/src/order-event.md
@@ -47,8 +47,8 @@ Events are [addressable events](https://github.com/nostr-protocol/nips/blob/mast
 ## Tags
 
 - `d` < Order ID >: A unique identifier for the order.
-- `k` < Order type >: `sell` or `buy`.
-- `f` < Currency >: The asset being traded, using the [ISO 4217](https://en.wikipedia.org/wiki/ISO_4217) standard.
+- `k` < Order type >: `sell` or `buy`. This specifies the type of transaction in terms of bitcoin. "sell" means selling bitcoin, while "buy" indicates buying bitcoin.
+- `f` < Currency >: The fiat asset being traded, using the [ISO 4217](https://en.wikipedia.org/wiki/ISO_4217) standard.
 - `s` < Status >: `pending`, `canceled`, `in-progress`, `success`.
 - `amt` < Amount >: The amount of Bitcoin to be traded, the amount is defined in satoshis, if `0` means that the amount of satoshis will be obtained from a public API after the taker accepts the order.
 - `fa` < Fiat amount >: The fiat amount being traded, for range orders two values are expected, the minimum and maximum amount.


### PR DESCRIPTION
# Context
While reviewing [this issue](https://github.com/MostroP2P/mostro-cli/issues/67), I noticed that some events mentioned were not included in the [mostro order event documentation](https://mostro.network/protocol/order-event.html). After checking mostro-core, I found additional statuses that aren't currently reflected in the documentation.

Additionally, as a new user of the CLI, I was unsure whether "sell" referred to selling Bitcoin or fiat, so I thought a clarification might be helpful for others.

# What Has Been Done
- Added the additional statuses found in mostro-core and removed the pending status, which wasn’t specified in mostro-core. **Update:** this was reverted, didn't make sense
- Included a small clarification for the -k tag to specify the order type more clearly.
# What to Check
- Whether all the added statuses should be public or if some are meant for internal use only within Mostro. **Update:** it didn't make sense
- If the clarification for the -k tag makes sense

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
	- Enhanced clarity and detail in the P2P order event specifications.
	- Expanded definitions for order type, currency, and status tags.
	- Introduced a broader range of order statuses for better categorization. 

- **Documentation**
	- Updated `order-event.md` to maintain structure while providing detailed information on order events.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->